### PR TITLE
Adding new top languages based on Github

### DIFF
--- a/code-stats.sh
+++ b/code-stats.sh
@@ -31,6 +31,9 @@ TYPES=(
   cpp cc cxx          # C++
   pl pm t ep          # Perl
   m mm                # Objective-C
+  ts                  # TypeScript
+  swift               # Swift
+  scala               # Scala
 
   ## More languages
 


### PR DESCRIPTION
I've been using your script to track progress on some side projects and just manually modified the list of languages. This is just adding the top languages on Github (according to this: https://octoverse.github.com/) that the script is missing.